### PR TITLE
FIX | cleanup some unnecessary []byte to string casts (breaks API)

### DIFF
--- a/modo2auth_test.go
+++ b/modo2auth_test.go
@@ -86,12 +86,11 @@ func TestSign(test *testing.T) {
 
 func TestGetToken(test *testing.T) {
 	modo := mockModo()
-	apiURI := []byte("/test")
 	body := mockBody()
 	expected :=
 		"MODO2 eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1OTAwNzI2ODUsImFwaV9pZGVudGlmaWVyIjoiN2cwVUFwaXBNcHVKMVZPT09IV0pOSVpIN1ZaSU5iMDgiLCJhcGlfdXJpIjoiL3Rlc3QiLCJib2R5X2hhc2giOiI0NmI4ZGFkMWM2OWNiZDUwMGU5ZDFmZTJmMmVjZTM1N2M4NGM2ZTM2Y2U3YTg2MGJmMTQ2NzJiNGI3NDBhZjE5In0.sWjjz_MpnSv8Z31gNpEm1cmDhN7MK7Z3ix61RbDRL7g"
 
-	token, err := GetToken(apiURI, body, modo)
+	token, err := GetToken("/test", body, modo)
 
 	if err != nil {
 		test.Error(err)
@@ -123,10 +122,8 @@ func TestBodyHash(test *testing.T) {
 }
 
 func TestMakePayload(test *testing.T) {
-	apiIdentifier := []byte("7g0UApipMpuJ1VOOOHWJNIZH7VZINb08")
-	apiURI := []byte("/payouts/minimum?action=complete")
 	body := mockBody()
-	payload, err := makePayload(apiURI, apiIdentifier, body, true)
+	payload, err := makePayload("/payouts/minimum?action=complete", "7g0UApipMpuJ1VOOOHWJNIZH7VZINb08", body, true)
 	data := string(payload)
 	expected := "eyJpYXQiOjE1OTAwNzI2ODUsImFwaV9pZGVudGlmaWVyIjoiN2cwVUFwaXBNcHVKMVZPT09IV0pOSVpIN1ZaSU5iMDgiLCJhcGlfdXJpIjoiL3BheW91dHMvbWluaW11bT9hY3Rpb249Y29tcGxldGUiLCJib2R5X2hhc2giOiI0NmI4ZGFkMWM2OWNiZDUwMGU5ZDFmZTJmMmVjZTM1N2M4NGM2ZTM2Y2U3YTg2MGJmMTQ2NzJiNGI3NDBhZjE5In0"
 
@@ -141,8 +138,7 @@ func TestMakePayload(test *testing.T) {
 func TestMakeSignature(test *testing.T) {
 	header := makeHeader()
 	payload := []byte("eyJpYXQiOjE1OTAwNzI2ODUsImFwaV9pZGVudGlmaWVyIjoiN2cwVUFwaXBNcHVKMVZPT09IV0pOSVpIN1ZaSU5iMDgiLCJhcGlfdXJpIjoiL3BheW91dHMvbWluaW11bT9hY3Rpb249Y29tcGxldGUiLCJib2R5X2hhc2giOiI0NmI4ZGFkMWM2OWNiZDUwMGU5ZDFmZTJmMmVjZTM1N2M4NGM2ZTM2Y2U3YTg2MGJmMTQ2NzJiNGI3NDBhZjE5In0")
-	apiSecret := []byte("20I1s7GH7-pgn9041cgWlBKU8pcA1I4CCNpGuvu_xL4K-GnRSy3Q6IBtA5LYlIjy")
-	signature := makeSignature(header, payload, apiSecret)
+	signature := makeSignature(header, payload, "20I1s7GH7-pgn9041cgWlBKU8pcA1I4CCNpGuvu_xL4K-GnRSy3Q6IBtA5LYlIjy")
 	data := string(signature)
 	expected := "lE865md6iVe42QyAGMpcm4bJntMACcDISfCxMrKzOuo"
 


### PR DESCRIPTION
Cleans up a few things I noticed. All tests continue to run.

Note: this would be a breaking change for users of the `GetToken` function, so it might be bad if anyone is using it (and they could be... since it's on GitHub)